### PR TITLE
Readme: Add Discord Chat Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/uuvsimulator/lauv_gazebo.svg?branch=master)](https://travis-ci.org/uuvsimulator/lauv_gazebo)
 [![GitHub issues](https://img.shields.io/github/issues/uuvsimulator/lauv_gazebo.svg)](https://github.com/uuvsimulator/lauv_gazebo/issues)
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
+[![Chat](https://img.shields.io/discord/870113194289532969.svg?style=flat-square&colorB=758ED3)](https://discord.gg/vq8PkDb2TC)
 
 > Link to the `lauv_gazebo` repository [here](https://github.com/uuvsimulator/lauv_gazebo)
 


### PR DESCRIPTION
I think having this chat badge helps make people feel like the project is more of a community, rather than just some code sitting somewhere, and increases the likelihood for others to join and contribute.

You can see how this will render below, showing the number of people currently online:

<img width="863" alt="image" src="https://user-images.githubusercontent.com/2559382/177860884-cc0bf909-a9ff-47e5-a8ba-365ecd6d3026.png">
